### PR TITLE
Pr 85 widget spacing and resizing

### DIFF
--- a/brainwave_reading_tab.py
+++ b/brainwave_reading_tab.py
@@ -116,6 +116,9 @@ class BrainwaveReading_Tab(QWidget):
         # Flight Log Section
         flight_log_label = QLabel("Flight Log")
         flight_log_label.setStyleSheet("color: white;")
+        # Reduce the gap between the label and the list
+        flight_log_label.setAlignment(Qt.AlignTop)
+
         self.flight_log_list = QListWidget()
         self.flight_log_list.setFixedSize(250, 150)
         self.flight_log_list.setStyleSheet("background-color: #1b3a4b; color: white; border: 1px solid white;")
@@ -137,16 +140,19 @@ class BrainwaveReading_Tab(QWidget):
         
         # Container to display the flight log list and synthetic live radios
         flight_log_and_radios_horizontal_layout = QHBoxLayout()
+        flight_log_and_radios_horizontal_layout.setAlignment(Qt.AlignLeft)
 
         # Vertical layout for flight log label and list
         flight_log_vertical_layout = QVBoxLayout()
-        flight_log_vertical_layout.setAlignment(Qt.AlignLeft)
         flight_log_vertical_layout.addWidget(flight_log_label)
-        flight_log_vertical_layout.addWidget(self.flight_log_list)
+        flight_log_vertical_layout.addWidget(self.flight_log_list, alignment=Qt.AlignTop) # Align the flight log list to the top
+
 
         # Add flight log controls to the horizontal layout
         flight_log_and_radios_horizontal_layout.addLayout(flight_log_vertical_layout)
         flight_log_and_radios_horizontal_layout.addWidget(synthetic_live_radios_box)
+        # Align the synthetic live radios to the top
+        flight_log_and_radios_horizontal_layout.setAlignment(synthetic_live_radios_box, Qt.AlignTop | Qt.AlignCenter)
         # Add the horizontal layout to the left layout
         left_layout.addLayout(flight_log_and_radios_horizontal_layout)
 


### PR DESCRIPTION
Set alignment of widgets, flight log label, flight log list, and radio buttons, to configure spacing. Set alignment to top instead of left to get rid of space between widgets. Child widgets were also set to alignment top to get rid of space inside boxes. 

![image](https://github.com/user-attachments/assets/70d23509-8ae2-447e-ae5d-ce5331be4512)
